### PR TITLE
The method run() of type TextForwarder should be tagged with @Override

### DIFF
--- a/src/main/java/de/codecentric/mule/TextForwarder.java
+++ b/src/main/java/de/codecentric/mule/TextForwarder.java
@@ -21,7 +21,8 @@ class TextForwarder extends Thread {
         this.destination = destination;
     }
 
-    public void run() {
+    @Override
+	public void run() {
         BufferedReader rd = new BufferedReader(new InputStreamReader(inputStream));
         String line = null;
         try {


### PR DESCRIPTION
since it actually overrides a superclass method